### PR TITLE
Feature/185866630 select num articles per page

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,6 +4,7 @@ class ArticlesController < ApplicationController
 
     @limit = params[:per_page].to_i
     @limit = 10 if @limit.zero?
+
     offset = @page - 1
 
     @page_count = (Article.count / @limit) + 1

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,12 +2,12 @@ class ArticlesController < ApplicationController
   def index
     @page = (params[:page].nil? ? 1 : params[:page]).to_i
 
-    limit = params[:per_page].to_i
-    limit = 10 if limit.zero?
+    @limit = params[:per_page].to_i
+    @limit = 10 if @limit.zero?
     offset = @page - 1
 
-    @page_count = (Article.count / limit) + 1
-    @articles = Article.limit(limit).offset(offset * limit)
+    @page_count = (Article.count / @limit) + 1
+    @articles = Article.limit(@limit).offset(offset * @limit)
   end
 
   def create

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -7,7 +7,7 @@ class ArticlesController < ApplicationController
 
     offset = @page - 1
 
-    @page_count = (Article.count / @limit) + 1
+    @total_pages = (Article.count / @limit) + 1
     @articles = Article.limit(@limit).offset(offset * @limit)
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -7,7 +7,9 @@ class ArticlesController < ApplicationController
 
     offset = @page - 1
 
-    @total_pages = (Article.count / @limit) + 1
+    pages = Article.count / @limit
+
+    @total_pages = (Article.count % @limit).zero? ? pages : pages + 1
     @articles = Article.limit(@limit).offset(offset * @limit)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,2 @@
 module ApplicationHelper
-  def path_with_params(path, params)
-    "#{path}?#{params.to_query}"
-  end
 end

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,2 +1,0 @@
-module ArticlesHelper
-end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,3 @@
+module PaginationHelper
+  ITEMS_PER_PAGE = [10, 20, 50].freeze
+end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -4,21 +4,22 @@
 
 <div class="text-center flex flex-col">
   <div>
-    <%= link_to icon('fa-solid', 'angles-left'), path_with_params(articles_path, { page: 1 }) %>
-    <%= link_to icon('fa-solid', 'chevron-left'), path_with_params(articles_path, { page: @page > 1 ? @page - 1 : @page }) %>
+    <%= link_to icon('fa-solid', 'angles-left'), controller: 'articles', action: 'index', page: 1, per_page: @limit %>
+    <%= link_to icon('fa-solid', 'chevron-left'), controller: 'articles', action: 'index', page: @page > 1 ? @page - 1 : @page, per_page: @limit %>
     <% 1.upto @page_count do |page| %>
-      <%= link_to page, path_with_params(articles_path, { page: page }) %>
+      <%= link_to page, controller: 'articles', action: 'index', page: page, per_page: @limit %>
     <% end %>
-    <%= link_to icon('fa-solid', 'chevron-right'), path_with_params(articles_path, { page: @page < @page_count ? @page + 1 : @page_count }) %>
-    <%= link_to icon('fa-solid', 'angles-right'), path_with_params(articles_path, { page: @page_count }) %>
+    <%= link_to icon('fa-solid', 'chevron-right'), controller: 'articles', action: 'index', page: @page < @page_count ? @page + 1 : @page_count, per_page: @limit %>
+    <%= link_to icon('fa-solid', 'angles-right'), controller: 'articles', action: 'index', page: @page_count, per_page: @limit %>
   </div>
   <div>
-    <%= select(
-      :article,
-      :page,
-      [*PaginationHelper::ITEMS_PER_PAGE],
-      selected: @limit,
-    ) %>
+    <%= form_with url: articles_path, method: 'GET' do |form| %>
+      <%= select_tag(
+        :per_page,
+        options_for_select([*PaginationHelper::ITEMS_PER_PAGE], @limit),
+        onchange: 'this.form.submit()',
+      ) %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -6,11 +6,11 @@
   <div>
     <%= link_to icon('fa-solid', 'angles-left'), controller: 'articles', action: 'index', page: 1, per_page: @limit %>
     <%= link_to icon('fa-solid', 'chevron-left'), controller: 'articles', action: 'index', page: @page > 1 ? @page - 1 : @page, per_page: @limit %>
-    <% 1.upto @page_count do |page| %>
+    <% 1.upto @total_pages do |page| %>
       <%= link_to page, controller: 'articles', action: 'index', page: page, per_page: @limit %>
     <% end %>
-    <%= link_to icon('fa-solid', 'chevron-right'), controller: 'articles', action: 'index', page: @page < @page_count ? @page + 1 : @page_count, per_page: @limit %>
-    <%= link_to icon('fa-solid', 'angles-right'), controller: 'articles', action: 'index', page: @page_count, per_page: @limit %>
+    <%= link_to icon('fa-solid', 'chevron-right'), controller: 'articles', action: 'index', page: @page < @total_pages ? @page + 1 : @total_pages, per_page: @limit %>
+    <%= link_to icon('fa-solid', 'angles-right'), controller: 'articles', action: 'index', page: @total_pages, per_page: @limit %>
   </div>
   <div>
     <%= form_with url: articles_path, method: 'GET' do |form| %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -16,7 +16,7 @@
     <%= form_with url: articles_path, method: 'GET' do |form| %>
       <%= select_tag(
         :per_page,
-        options_for_select([*PaginationHelper::ITEMS_PER_PAGE], @limit),
+        options_for_select(PaginationHelper::ITEMS_PER_PAGE, @limit),
         onchange: 'this.form.submit()',
       ) %>
     <% end %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -4,16 +4,16 @@
 
 <div class="text-center flex flex-col">
   <div>
-    <%= link_to icon('fa-solid', 'angles-left'), controller: 'articles', action: 'index', page: 1, per_page: @limit %>
-    <%= link_to icon('fa-solid', 'chevron-left'), controller: 'articles', action: 'index', page: @page > 1 ? @page - 1 : @page, per_page: @limit %>
+    <%= link_to icon('fa-solid', 'angles-left'), root_path({ page: 1, per_page: @limit }) %>
+    <%= link_to icon('fa-solid', 'chevron-left'), root_path({ page: @page > 1 ? @page - 1 : @page, per_page: @limit }) %>
     <% 1.upto @total_pages do |page| %>
-      <%= link_to page, controller: 'articles', action: 'index', page: page, per_page: @limit %>
+      <%= link_to page, root_path({ page: page, per_page: @limit }) %>
     <% end %>
-    <%= link_to icon('fa-solid', 'chevron-right'), controller: 'articles', action: 'index', page: @page < @total_pages ? @page + 1 : @total_pages, per_page: @limit %>
-    <%= link_to icon('fa-solid', 'angles-right'), controller: 'articles', action: 'index', page: @total_pages, per_page: @limit %>
+    <%= link_to icon('fa-solid', 'chevron-right'), root_path({ page: @page < @total_pages ? @page + 1 : @total_pages, per_page: @limit }) %>
+    <%= link_to icon('fa-solid', 'angles-right'), root_path({ page: @total_pages, per_page: @limit }) %>
   </div>
   <div>
-    <%= form_with url: articles_path, method: 'GET' do |form| %>
+    <%= form_with url: root_path, method: 'GET' do |form| %>
       <%= select_tag(
         :per_page,
         options_for_select(PaginationHelper::ITEMS_PER_PAGE, @limit),

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -13,7 +13,7 @@
     <%= link_to icon('fa-solid', 'angles-right'), path_with_params(articles_path, { page: @page_count }) %>
   </div>
   <div>
-    <%= select(:article, :page, 1..@page_count) %>
+    <%= select(:article, :page, [*PaginationHelper::ITEMS_PER_PAGE]) %>
   </div>
 </div>
 

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -13,7 +13,12 @@
     <%= link_to icon('fa-solid', 'angles-right'), path_with_params(articles_path, { page: @page_count }) %>
   </div>
   <div>
-    <%= select(:article, :page, [*PaginationHelper::ITEMS_PER_PAGE]) %>
+    <%= select(
+      :article,
+      :page,
+      [*PaginationHelper::ITEMS_PER_PAGE],
+      selected: @limit,
+    ) %>
   </div>
 </div>
 

--- a/spec/requests/article_spec.rb
+++ b/spec/requests/article_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe 'Articles', type: :request do
       expect(response).to render_template(:index)
     end
 
-    it 'assigns @page, @page_count, @articles variables' do
+    it 'assigns @page, @total_pages, @articles variables' do
       expect(assigns(:page)).to_not eq(nil)
-      expect(assigns(:page_count)).to_not eq(nil)
+      expect(assigns(:total_pages)).to_not eq(nil)
       expect(assigns(:articles)).to_not eq(nil)
     end
   end

--- a/spec/requests/article_spec.rb
+++ b/spec/requests/article_spec.rb
@@ -33,6 +33,27 @@ RSpec.describe 'Articles', type: :request do
     end
   end
 
+  describe 'GET :index with per_page' do
+    it 'dynamically assigns @total_pages when per_page changes', focus: true do
+      FactoryBot.create_list(:article, 50)
+
+      get articles_path, params: { per_page: 5 }
+      expect(assigns(:total_pages)).to eq(10)
+
+      get articles_path, params: { per_page: 10 }
+      expect(assigns(:total_pages)).to eq(5)
+
+      get articles_path, params: { per_page: 25 }
+      expect(assigns(:total_pages)).to eq(2)
+
+      get articles_path, params: { per_page: 30 }
+      expect(assigns(:total_pages)).to eq(2)
+
+      get articles_path, params: { per_page: 50 }
+      expect(assigns(:total_pages)).to eq(1)
+    end
+  end
+
   describe 'GET :new' do
     before(:each) do
       get new_article_path


### PR DESCRIPTION
# Description, Motivation, and Context

This PR adds a dropdown list to select how many articles per page will be shown!
The list will send a GET request to the `/articles` route and fetch differing numbers of `total_count`, as well as change how many articles are actually fetched by the request.
