### PR TITLE
186358565: Add htmlbeautifier gem to lint ERB files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
   gem 'faker', git: 'https://github.com/faker-ruby/faker.git', branch: 'main'
+  gem 'htmlbeautifier'
   gem 'rubocop', '~> 1.57', require: false
   gem 'rubocop-factory_bot', '~> 2.24'
   gem 'rubocop-rails', '~> 2.22'

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,6 @@ group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
   gem 'faker', git: 'https://github.com/faker-ruby/faker.git', branch: 'main'
-  gem 'htmlbeautifier'
   gem 'rubocop', '~> 1.57', require: false
   gem 'rubocop-factory_bot', '~> 2.24'
   gem 'rubocop-rails', '~> 2.22'
@@ -76,6 +75,7 @@ group :test do
 end
 
 group :development do
+  gem 'htmlbeautifier'
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
       sassc (~> 2.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    htmlbeautifier (1.4.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.1.5)
@@ -297,6 +298,7 @@ DEPENDENCIES
   factory_bot_rails
   faker!
   font-awesome-sass (~> 6.2.1)
+  htmlbeautifier
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,9 +1,6 @@
 <h1 class="text-3xl text-center font-bold ">Home</h1>
-
 <br>
-
 <%= render 'shared/pagination', locals: { pagination: @pagination } %>
-
 <table class="text-center">
   <thead>
     <tr>


### PR DESCRIPTION
# Description, Motivation, and Context

This PR was created to enhance developer experience when working with ERB files.
A gem `htmlbeautifier` was added to lint ERB files on save.

There are setup steps to get this to work (currently only supports VSCode in this repository):
1. Run `bundle install`
2. Add the following config variables to your VSCode `settings.json` file:

```
"[erb]": {
  "editor.defaultFormatter": "aliariff.vscode-erb-beautify",
  "editor.formatOnSave": true
},
"files.associations": {
  "*.html.erb": "erb"
},
"vscode-erb-beautify.useBundler": true
```
3. Open up a `.erb` file. Mess with it, and try saving. The file should reformat and lint itself.
